### PR TITLE
Remove redundancy of variable declaration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 ## Catch Me
-A silly little game with [Nyan Cat](http://www.nyan.cat/) background music.
+Is a game to test your speed, do you think you are fast with your mouse?
+
+Every time you put the arrow inside the box you got a point.
+Enjoy the game with the nyan cat song! :rainbow:
 
 ![](https://i.imgur.com/3GclP2f.gif)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 Is a game to test your speed, do you think you are fast with your mouse?
 
 Every time you put the arrow inside the box you got a point.
-Enjoy the game with the nyan cat song! :rainbow:
+Enjoy the game with the [Nyan Cat](http://www.nyan.cat/) song! :rainbow:
 
 ![](https://i.imgur.com/3GclP2f.gif)

--- a/script.js
+++ b/script.js
@@ -7,27 +7,27 @@ const diff_enum = {
 };
 
 // Utility Functions
-const mv_x = (what, x) => what.style.left = x;
-const mv_y = (what, y) => what.style.top = y;
-const rand = (limit) => Math.random() * limit;
-const inRange = (lower, upper, what) => what >= lower && what <= upper;
+const mv_x = (what, x) => what.style.left = x,
+    mv_y = (what, y) => what.style.top = y,
+    rand = (limit) => Math.random() * limit,
+    inRange = (lower, upper, what) => what >= lower && what <= upper;
 
 // Selectors. Duh!
-const catch_me = document.getElementById("catch_me");
-const counter = document.getElementById("counter");
-const body = document.querySelectorAll(".body")[0];
+const catch_me = document.getElementById("catch_me"),
+    counter = document.getElementById("counter"),
+    body = document.querySelectorAll(".body")[0];
 
 // Useful global values
-const catch_height = 50;
-const catch_width = 100;
-const difficulty = diff_enum.HARD; // CHANGE THIS FOR MORE FUN
+const catch_height = 50,
+    catch_width = 100,
+    difficulty = diff_enum.HARD; // CHANGE THIS FOR MORE FUN
 
 const incr_counter = () => counter.innerText = +counter.innerText + 1;
 // Next positions should be within the visible portion of the window.
-const rand_x = () => rand(window.innerWidth - catch_width);
-const rand_y = () => rand(window.innerHeight - catch_height);
-const mv_catch_x = () => mv_x(catch_me, rand_x());
-const mv_catch_y = () => mv_y(catch_me, rand_y());
+const rand_x = () => rand(window.innerWidth - catch_width),
+    rand_y = () => rand(window.innerHeight - catch_height),
+    mv_catch_x = () => mv_x(catch_me, rand_x()),
+    mv_catch_y = () => mv_y(catch_me, rand_y());
 
 // Initial State
 catch_me.style.position = "absolute";
@@ -47,10 +47,10 @@ catch_me.addEventListener("mouseenter", () => {
 
 // Track mouse movent inside body.
 body.addEventListener("mousemove", e => {
-    const delta_x = e.offsetX - catch_me.offsetLeft;
-    const delta_y = e.offsetY - catch_me.offsetTop;
-    const xInRange = inRange(-difficulty, difficulty + catch_width, delta_x);
-    const yInRange = inRange(-difficulty, difficulty + catch_height, delta_y);
+    const delta_x = e.offsetX - catch_me.offsetLeft,
+        delta_y = e.offsetY - catch_me.offsetTop,
+        xInRange = inRange(-difficulty, difficulty + catch_width, delta_x),
+        yInRange = inRange(-difficulty, difficulty + catch_height, delta_y);
     if (xInRange && yInRange) {
         mv_catch_x();
         mv_catch_y();


### PR DESCRIPTION
When declaring a variable is normal to use commas if the declaration are equals, exemple:

```js
var x = 10, y = 20;
const x = 1, r = 200;
```